### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-update-using-golang.yml
+++ b/.github/workflows/auto-update-using-golang.yml
@@ -1,6 +1,10 @@
 # Name of the GitHub Actions workflow
 name: Run Go Script and Push Changes
 
+# Define the permissions for the workflow
+permissions:
+  contents: write
+
 # Define the events that trigger this workflow
 on:
   # Run automatically on a schedule (daily at midnight UTC)


### PR DESCRIPTION
Potential fix for [https://github.com/Strong-Foundation/msdsauthoring-com-documentation/security/code-scanning/1](https://github.com/Strong-Foundation/msdsauthoring-com-documentation/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for the workflow to function correctly. Since the workflow involves reading the repository contents and pushing changes, we will set `contents: write`. This ensures that the workflow has only the necessary permissions and no more.

The `permissions` block will be added at the root level of the workflow, applying to all jobs. This is the most efficient approach since the workflow contains only one job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
